### PR TITLE
Fix building Iridium OSX with -m nosign flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -242,7 +242,7 @@ if [[ -z $NO_PATCHING ]]; then
 			fi
 			;;
 		"nosign")
-			./iridium-osx-patch.sh
+			./iridium-osx-patch.sh -m nosign
 			;;
 		*)
 			echo "Unknown parameter"


### PR DESCRIPTION
Building Iridium for OSX failed when using the -m nosign option, now passing it on to iridium-osx-patch.sh
